### PR TITLE
Add Calcit

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ Mapping the constellation of [Clojure](https://en.wikipedia.org/wiki/Clojure)-li
 * Built-in gradual type system which allows for malli-style type annotations which result in static type analysis.
 * [Work in progress](https://jank-lang.org/progress/)
 
+### [Calcit](http://calcit-lang.org/)
+
+> Heavily influenced by Clojure APIs, Macros, persistent data structure. Previously compiling to Clojure.
+
+* Implemented in Rust. It was previously compiled to Clojure to run.
+* Builtin persistent data structure. Shares many functions/macros API designs from Clojure.
+* Designed like Lisp but prefers indentation based syntax or GUI code editor.
+
 # Mal [make-a-lisp](https://github.com/kanaka/mal)
 
 > Mal is a Clojure inspired Lisp interpreter. Mal is **implemented in 63 languages**.
@@ -193,4 +201,3 @@ Notable/usable implementations follow.
 ### [mal/ruby](https://github.com/kanaka/mal/tree/master/ruby)
 
  * Implements the #mal IRC bot.
-


### PR DESCRIPTION
Before Calcit made it viable to run Cirru with an interpreter, code written in Cirru was compiled to Clojure with a plugin called [sepal.clj](https://github.com/Cirru/sepal.clj) so that shadow-cljs can compile. As a result Calcit shares many Clojure APIs, only small part of them are changed. Many libraries remained working even after I changed the implementing language(with some modifications), for example:

- https://github.com/Respo/respo.cljs
- https://github.com/Respo/respo.calcit

No doubt that Calcit is a dialect of Clojure, or ClojureScript more specifically. Some features are customized to fit my own cases, which are listed on http://repo.calcit-lang.org/guidebook/intro/from-clojure.html .
