### PR TITLE
Update Hy "Try it" URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Mapping the constellation of [Clojure](https://en.wikipedia.org/wiki/Clojure)-li
 
 > Hy is a wonderful dialect of Lisp that’s embedded in Python.
 
- * [Try it](https://try-hy.appspot.com/).
+ * [Try it](https://hylang.org/try-hy).
  * [Source code](https://github.com/hylang/hy).
  * High level of interop with host language.
  * All of available Python tooling available.


### PR DESCRIPTION
The link to Hy's online REPL was borked. This PR aims to rectify that situation by updating the link and having an unnecessarily long pull request description.