### PR TITLE
Fix submission template entry heading level

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -15,7 +15,7 @@ Basically if it looks and smells like Clojure then it's a candidate for inclusio
 
 ### Submission template
 
-	## [Language name](http://link-to-language-site/)
+	### [Language name](http://link-to-language-site/)
 	
 	> Language tagline from website.
 	


### PR DESCRIPTION
Changes submission template in the contribution guide to use H3 (`###`) rather than H2 (`##`) to match the current README structure.